### PR TITLE
:sparkles: 글 수정하기 기능 구현

### DIFF
--- a/src/components/article/question/QuestionAddForm.vue
+++ b/src/components/article/question/QuestionAddForm.vue
@@ -58,11 +58,11 @@ export default {
           content: this.content,
           hashtags: this.hashtags,
         });
-        this.$router.push('/home');
-        console.log(response);
+        this.$router.push(
+          `/community/${this.$route.params.type}/${response.data}`,
+        );
       } catch (error) {
-        console.log(error.response.data);
-        // console.log(error.response.data.message);
+        console.log(error.response.data.message);
       }
     },
   },

--- a/src/components/article/question/QuestionDetailForm.vue
+++ b/src/components/article/question/QuestionDetailForm.vue
@@ -15,8 +15,12 @@
       >
         #{{ tag }}
       </div>
-      <b-button class="float-right mt-2" variant="info" @click="addQuestion"
-        >등록</b-button
+      <b-button
+        v-show="this.item.sameWriter"
+        class="float-right mt-2"
+        variant="info"
+        @click="routeEditForm"
+        >수정</b-button
       >
       <b-button class="float-right mt-2 m-1" variant="outline-info"
         >취소</b-button
@@ -31,7 +35,6 @@ export default {
   data() {
     return {
       item: [],
-      id: '',
     };
   },
   methods: {
@@ -40,8 +43,13 @@ export default {
         this.$route.params.type,
         this.$route.params.id,
       );
-      console.log(this.id);
       this.item = data;
+    },
+
+    routeEditForm() {
+      this.$router.push(
+        `/community/${this.$route.params.type}/${this.$route.params.id}/edit`,
+      );
     },
   },
   created() {

--- a/src/components/article/question/QuestionEditForm.vue
+++ b/src/components/article/question/QuestionEditForm.vue
@@ -21,7 +21,7 @@
       <b-form-tags
         class="mt-2"
         input-id="tags-pills"
-        v-model="hashtag"
+        v-model="hashtags"
         tag-variant="primary"
         tag-pills
         size="lg"
@@ -30,7 +30,7 @@
         remove-on-delete
         duplicateTagText="중복된 입력입니다"
       ></b-form-tags>
-      <b-button class="float-right mt-2" variant="info" @click="addQuestion"
+      <b-button class="float-right mt-2" variant="info" @click="editArticle"
         >등록</b-button
       >
       <b-button class="float-right mt-2 m-1" variant="outline-info"
@@ -48,30 +48,28 @@ export default {
       title: '',
       content: '',
       hashtags: [],
+      type: '',
+      id: '',
     };
   },
   methods: {
     async editArticle() {
       try {
-        const response = await edit(
-          this.$router.params.type,
-          this.$router.params.id,
-          {
-            title: this.title,
-            content: this.content,
-            hashtags: this.hashtags,
-          },
-        );
-        this.$router.push('/home');
-        console.log(response);
+        await edit(this.type, this.id, {
+          title: this.title,
+          content: this.content,
+          hashtags: this.hashtags,
+        });
+        this.$router.push(`/community/${this.type}/${this.id}`);
       } catch (error) {
-        console.log(error.response.data.message);
+        console.log(error.response);
       }
     },
   },
   async created() {
-    const id = this.$router.params.id;
-    const { data } = await fetchDetail(id);
+    this.type = this.$router.history.current.params.type;
+    this.id = this.$router.history.current.params.id;
+    const { data } = await fetchDetail(this.type, this.id);
     this.title = data.title;
     this.content = data.content;
     this.hashtags = data.hashtags;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -32,6 +32,10 @@ export default new VueRouter({
         import('@/views/Article/Question/QuestionDetailPage.vue'),
     },
     {
+      path: '/community/:type/:id/edit',
+      component: () => import('@/views/Article/Question/QuestionEditPage.vue'),
+    },
+    {
       path: '*',
       component: () => import('@/views/NotFoundPage.vue'),
     },

--- a/src/views/Article/Question/QuestionEditPage.vue
+++ b/src/views/Article/Question/QuestionEditPage.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="form-container">
+    <question-edit-form></question-edit-form>
+  </div>
+</template>
+
+<script>
+import QuestionEditForm from '@/components/article/question/QuestionEditForm.vue';
+
+export default {
+  components: { QuestionEditForm },
+  comments: {
+    QuestionEditForm,
+  },
+};
+</script>
+
+<style></style>


### PR DESCRIPTION
- 글 수정 및 작성 시 해당 글의 상세 페이지로 이동한다.
- EditForm의 경우 id와 타입을 가져오는 방법이 기존과 달라졌는데 추후 왜 this.$route.params가 되지 않는지 학습 후 보완 예정